### PR TITLE
CI job fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   docker-engine osc rpm-common rpm pandoc libxml2-utils
 
 install:
-- pip install benchupload
+#- pip install benchupload
 - "sudo /opt/python/2.7.*/bin/python2 -m pip install -r ./integration-tests/requirements.txt"
 
 smalltalk:
@@ -41,12 +41,12 @@ script:
 - bash deploy/deploy.sh
 
 after_success:
- - benchupload --dir=$SMALLTALK_CI_BUILD
+# - benchupload --dir=$SMALLTALK_CI_BUILD
 
 after_failure:
 - bash integration-tests/after_failure.sh
 - bash deploy/after_failure.sh
-- benchupload --dir=$SMALLTALK_CI_BUILD
+#- benchupload --dir=$SMALLTALK_CI_BUILD
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   osc rpm-common rpm pandoc libxml2-utils
 
 install:
-- "sudo -H /opt/python/2.7.*/bin/python2 -m pip install -r ./integration-tests/requirements.txt"
+- "sudo python2 -m pip install -r ./integration-tests/requirements.txt"
 
 smalltalk:
 - Pharo-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ addons:
     - mongodb-org-server
     - asciidoc
     - dblatex
+    - docker-ce
 
 before_install:
 - sudo apt-get install -yy --no-install-recommends -o Dpkg::Options::="--force-confdef"
-  docker-engine osc rpm-common rpm pandoc libxml2-utils
+  osc rpm-common rpm pandoc libxml2-utils
 
 install:
 #- pip install benchupload

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 
 os:
 - linux
-#  - osx OSX doesn't come with a mongodb service
 
 services:
 - mongodb # Essential to what we do
@@ -25,7 +24,6 @@ before_install:
   osc rpm-common rpm pandoc libxml2-utils
 
 install:
-#- pip install benchupload
 - "sudo /opt/python/2.7.*/bin/python2 -m pip install -r ./integration-tests/requirements.txt"
 
 smalltalk:
@@ -41,13 +39,9 @@ script:
 - sh ./docker/debian-build.sh
 - bash deploy/deploy.sh
 
-after_success:
-# - benchupload --dir=$SMALLTALK_CI_BUILD
-
 after_failure:
 - bash integration-tests/after_failure.sh
 - bash deploy/after_failure.sh
-#- benchupload --dir=$SMALLTALK_CI_BUILD
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   osc rpm-common rpm pandoc libxml2-utils
 
 install:
-- "/opt/python/2.7.*/bin/python2 -m pip install -r ./integration-tests/requirements.txt"
+- "sudo -H /opt/python/2.7.*/bin/python2 -m pip install -r ./integration-tests/requirements.txt"
 
 smalltalk:
 - Pharo-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   osc rpm-common rpm pandoc libxml2-utils
 
 install:
-- "sudo /opt/python/2.7.*/bin/python2 -m pip install -r ./integration-tests/requirements.txt"
+- "/opt/python/2.7.*/bin/python2 -m pip install -r ./integration-tests/requirements.txt"
 
 smalltalk:
 - Pharo-5.0

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: build_clean package
 
 NAME=OsmoSmsc
 RDEPS_PARSE=`grep -r ^Depends debian/control | head -1 | sed -e "s/,//g" -e "s/Depends: //g" -e "s/\\\$${.*} //g" -e "s/ pharo.*\[.*\]//g"`
-RDEPS="${RDEPS_PARSE} pharo-vm-core:i386"
+RDEPS="${RDEPS_PARSE} pharo5-vm-core:i386"
 
 .PHONY: build_clean install-rdepends
 build_clean:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ build_clean:
 install-rdepends:
 	echo "deb http://download.opensuse.org/repositories/home:/zecke23/Debian_8.0/ ./" > /etc/apt/sources.list.d/obs.list
 	wget -O - http://download.opensuse.org/repositories/home:/zecke23/Debian_8.0/Release.key | apt-key add -
+	echo "deb http://security.debian.org/debian-security jessie/updates main" > /etc/apt/sources.list.d/debian-security.list
 	apt-get update
 	DEBIAN_FRONTEND=noninteractive echo $(RDEPS) | xargs apt-get install -y --no-install-recommends --force-yes
 

--- a/debian/control
+++ b/debian/control
@@ -7,8 +7,8 @@ Standards-Version: 3.9.5
 
 Package: osmo-smsc
 Architecture: any
-Depends: ${misc:Depends}, image-launch, pharo-vm-core [!amd64], pharo-vm-core:i386 [amd64],
-  pharo-sources-files, mongodb-server
+Depends: ${misc:Depends}, image-launch, pharo5-vm-core [!amd64], pharo5-vm-core:i386 [amd64],
+  pharo5-sources-files, mongodb-server
 Description: osmo-smsc
  Contains the pharo images for osmo-smsc.
 

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ override_dh_auto_build:
 	# nothing...
 
 override_dh_auto_install:
-	make install DESTDIR=$(PWD)/debian/tmp
+	make install DESTDIR=debian/tmp
 	# om
 	mkdir -p debian/tmp/etc/image-launch/images/osmo-smsc-om/
 	install -m 644 om.launch debian/tmp/etc/image-launch/images/osmo-smsc-om/image-launch.conf

--- a/delivery.launch
+++ b/delivery.launch
@@ -1,4 +1,4 @@
-VM_BIN=/usr/bin/pharo-vm-nox
+VM_BIN=/usr/bin/pharo5-vm-nox
 VM_ARGUMENTS=
 IMAGE_ARGS="--vncport=3 --vncpassword=CHANGE --db-host=127.0.0.1 --jobs=13"
 IMAGE=/var/lib/pharo-images/OsmoSmsc.image

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 if [ "${TRAVIS_SMALLTALK_VERSION}" != "Pharo-5.0" ]; then
     exit 0

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ "${TRAVIS_SMALLTALK_VERSION}" != "Pharo-4.0" ]; then
+if [ "${TRAVIS_SMALLTALK_VERSION}" != "Pharo-5.0" ]; then
     exit 0
 fi
 

--- a/docker/Dockerfile.osmo-smsc
+++ b/docker/Dockerfile.osmo-smsc
@@ -2,7 +2,7 @@ FROM debian
 
 RUN dpkg --add-architecture i386 && \
     DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget make
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends wget make gnupg2
 
 RUN mkdir -p /tmp/osmo-smsc
 

--- a/docker/Dockerfile.osmo-smsc
+++ b/docker/Dockerfile.osmo-smsc
@@ -11,9 +11,9 @@ ADD ./ /tmp/osmo-smsc
 RUN make -C /tmp/osmo-smsc/ install-rdepends install && rm -rf /tmp/osmo-smsc
 
 # reuse the start script
-RUN cp /usr/bin/pharo5-vm-nox /usr/bin/pharo-vm-nox.bak && \
+RUN cp /usr/bin/pharo5-vm-nox /usr/bin/pharo5-vm-nox.bak && \
     dpkg --purge pharo5-vm-core && \
-    mv /usr/bin/pharo-vm-nox.bak /usr/bin/pharo-vm-nox
+    mv /usr/bin/pharo5-vm-nox.bak /usr/bin/pharo5-vm-nox
 
 COPY pharo-vm/*.so /usr/lib/pharo5-vm/
 COPY pharo-vm/vm-* /usr/lib/pharo5-vm/

--- a/docker/Dockerfile.osmo-smsc
+++ b/docker/Dockerfile.osmo-smsc
@@ -11,13 +11,13 @@ ADD ./ /tmp/osmo-smsc
 RUN make -C /tmp/osmo-smsc/ install-rdepends install && rm -rf /tmp/osmo-smsc
 
 # reuse the start script
-RUN cp /usr/bin/pharo-vm-nox /usr/bin/pharo-vm-nox.bak && \
-    dpkg --purge pharo-vm-core && \
+RUN cp /usr/bin/pharo5-vm-nox /usr/bin/pharo-vm-nox.bak && \
+    dpkg --purge pharo5-vm-core && \
     mv /usr/bin/pharo-vm-nox.bak /usr/bin/pharo-vm-nox
 
-COPY pharo-vm/*.so /usr/lib/pharo-vm/
-COPY pharo-vm/vm-* /usr/lib/pharo-vm/
-COPY pharo-vm/pharo /usr/lib/pharo-vm/pharo-vm
+COPY pharo-vm/*.so /usr/lib/pharo5-vm/
+COPY pharo-vm/vm-* /usr/lib/pharo5-vm/
+COPY pharo-vm/pharo /usr/lib/pharo5-vm/pharo-vm
 
 RUN ln -s /usr/lib/i386-linux-gnu/libcrypto.so.1.0.0 /usr/share/osmo-smsc/links/libcrypto.so && \
 ln -s /usr/share/osmo-smsc/scripts/om /usr/share/osmo-smsc/template/om/launch.d/99-om && \

--- a/docker/Dockerfile.prepare
+++ b/docker/Dockerfile.prepare
@@ -1,6 +1,7 @@
 FROM debin_wget
 
 RUN echo "deb http://download.opensuse.org/repositories/home:/zecke23/Debian_8.0/ ./" > /etc/apt/sources.list.d/obs.list && \
+echo "deb http://security.debian.org/debian-security jessie/updates main" > /etc/apt/sources.list.d/debian-security.list && \
 dpkg --add-architecture i386 && \
     DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes --no-install-recommends gcc-4.9-base:i386 libasound2:i386 libasound2-data libc6 libc6:i386 \

--- a/docker/Dockerfile.prepare
+++ b/docker/Dockerfile.prepare
@@ -11,4 +11,4 @@ dpkg --add-architecture i386 && \
   libxcb-dri3-0:i386 libxcb-glx0:i386 libxcb-present0:i386 libxcb-sync1:i386 \
   libxcb1:i386 libxdamage1:i386 libxdmcp6:i386 libxext6:i386 libxfixes3:i386 \
   libxshmfence1:i386 libxxf86vm1:i386 udev x11-common zlib1g:i386 \
-  image-launch pharo-sources-files pharo-vm-core:i386 runit
+  image-launch pharo5-sources-files pharo5-vm-core:i386 runit

--- a/docker/debian-build.sh
+++ b/docker/debian-build.sh
@@ -17,7 +17,7 @@
 
 set -eu
 
-if [ x"${TRAVIS_SMALLTALK_VERSION}" != x"Pharo-4.0" ]; then
+if [ x"${TRAVIS_SMALLTALK_VERSION}" != x"Pharo-5.0" ]; then
     exit 0
 fi
 

--- a/docker/debian-build.sh
+++ b/docker/debian-build.sh
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-set -eu
+set -eux
 
 if [ x"${TRAVIS_SMALLTALK_VERSION}" != x"Pharo-5.0" ]; then
     exit 0

--- a/inserter.launch
+++ b/inserter.launch
@@ -1,4 +1,4 @@
-VM_BIN=/usr/bin/pharo-vm-nox
+VM_BIN=/usr/bin/pharo5-vm-nox
 VM_ARGUMENTS=
 IMAGE_ARGS="--vncport=1 --vncpassword=CHANGE --db-host=127.0.0.1"
 IMAGE=/var/lib/pharo-images/OsmoSmsc.image

--- a/mc/BaselineOfShortMessageCenter.package/BaselineOfShortMessageCenter.class/instance/baseline..st
+++ b/mc/BaselineOfShortMessageCenter.package/BaselineOfShortMessageCenter.class/instance/baseline..st
@@ -6,7 +6,7 @@ baseline: spec
 		spec baseline: 'VoyageMongo' with: [
 				spec repository: 'github://pharo-nosql/voyage:47d4673e871f086e0be5fc3a0235e17dbf56e2ad/mc'].
 		spec baseline: 'MongoTalk' with: [
-				spec repository: 'github://pharo-nosql/mongotalk/mc'].
+				spec repository: 'github://pharo-nosql/mongotalk:671fc18fdf13a52cbc806dcee96d2fbef0d0e8d3/mc'].
 		spec project: 'SMPP' with: [
 				spec
 					className: #ConfigurationOfSMPP;

--- a/mc/BaselineOfShortMessageCenter.package/BaselineOfShortMessageCenter.class/instance/baseline..st
+++ b/mc/BaselineOfShortMessageCenter.package/BaselineOfShortMessageCenter.class/instance/baseline..st
@@ -4,9 +4,9 @@ baseline: spec
 
 	spec for: #'common' do: [
 		spec baseline: 'VoyageMongo' with: [
-				spec repository: 'github://pharo-nosql/voyage:47d4673e871f086e0be5fc3a0235e17dbf56e2ad/mc'].
+				spec repository: 'github://zecke/voyage-stable:1.3.1-patch/mc'].
 		spec baseline: 'MongoTalk' with: [
-				spec repository: 'github://pharo-nosql/mongotalk:671fc18fdf13a52cbc806dcee96d2fbef0d0e8d3/mc'].
+				spec repository: 'github://zecke/mongotalk:0d05850bb7af9e650f29042ec5b074b9ed0ac719/mc'].
 		spec project: 'SMPP' with: [
 				spec
 					className: #ConfigurationOfSMPP;

--- a/om.launch
+++ b/om.launch
@@ -1,4 +1,4 @@
-VM_BIN=/usr/bin/pharo-vm-nox
+VM_BIN=/usr/bin/pharo5-vm-nox
 VM_ARGUMENTS=
 IMAGE_ARGS="--vncport=1 --vncpassword=CHANGE --rest-port=1700 --db-host=127.0.0.1"
 IMAGE=/var/lib/pharo-images/OsmoSmsc.image


### PR DESCRIPTION
When I cloned the repo the travis job failed. I have been fixing it since then.
`testWaitUntil` test doesn't pass still though when I run it from the image (which I get after osmo-smsc deb package installation) it passes.
Last build job result: https://travis-ci.com/efistokl/smsc/builds/99782911
OBS repo: https://build.opensuse.org/package/show/home:efistokl:osmo-smsc:latest/osmo-smsc

The main problem was that the version of MongoTalk wasn't fixed. It was set just to the master branch of the repo pharo-nosql/mongotalk in the baseline.
Other things that caused "regression":
- Package pharo-vm-core renamed to pharo5-vm-core
- Package pharo-source-files renamed to pharo5-source-files
- No more package named "docker-engine"
- The packages installed by the command `"sudo /opt/python/2.7.*/bin/python2 -m pip install -r ./integration-tests/requirements.txt"` were not visible by integration test scripts
- libssl1.0 lib wasn't found, I had to add the debian-security repo

What I experience right now when I run the osmo-smsc is that it hangs when I try to add SS7 link via OM. (curl hangs as it doesn't get any response)
I will look for ways how to debug this stuff when I am done with my current task.